### PR TITLE
Arreglo para poder crear release con sonidos

### DIFF
--- a/client/src/game/handlers/DefaultAOAssetManager.java
+++ b/client/src/game/handlers/DefaultAOAssetManager.java
@@ -170,7 +170,8 @@ public class DefaultAOAssetManager extends AssetManager implements AOAssetManage
     @Override
     public Music getMusic(int key) {
         if (Gdx.files.internal(Resources.GAME_MUSIC_PATH + key + Resources.GAME_MUSIC_EXTENSION).exists()) {
-            return get(Resources.GAME_MUSIC_PATH + key + Resources.GAME_MUSIC_EXTENSION);
+            return Gdx.audio.newMusic ( Gdx.files.internal
+                    (Resources.GAME_MUSIC_PATH + key + Resources.GAME_MUSIC_EXTENSION ) );
         } else {
             return null;
         }
@@ -179,7 +180,8 @@ public class DefaultAOAssetManager extends AssetManager implements AOAssetManage
     @Override
     public Sound getSound(int key) {
         if (Gdx.files.internal(Resources.GAME_SOUNDS_PATH + key + Resources.GAME_SOUNDS_EXTENSION).exists()) {
-            return get(Resources.GAME_SOUNDS_PATH + key + Resources.GAME_SOUNDS_EXTENSION);
+            return Gdx.audio.newSound (Gdx.files.internal
+                    (Resources.GAME_SOUNDS_PATH + key + Resources.GAME_SOUNDS_EXTENSION));
         } else {
             return null;
         }

--- a/client/src/game/screens/GameScreen.java
+++ b/client/src/game/screens/GameScreen.java
@@ -8,6 +8,7 @@ import com.artemis.managers.TagManager;
 import com.artemis.managers.UuidEntityManager;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.ScreenAdapter;
+import com.badlogic.gdx.audio.Music;
 import com.badlogic.gdx.graphics.FPSLogger;
 import com.badlogic.gdx.graphics.OrthographicCamera;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
@@ -60,6 +61,7 @@ public class GameScreen extends ScreenAdapter implements WorldScreen {
     private SpriteBatch spriteBatch;
     private WorldConfigurationBuilder worldConfigBuilder;
     private AOAssetManager assetManager;
+    private Music backGroundMusic;
 
     public GameScreen(ClientConfiguration clientConfiguration, AOAssetManager assetManager) {
         this.clientConfiguration = clientConfiguration;
@@ -163,11 +165,10 @@ public class GameScreen extends ScreenAdapter implements WorldScreen {
                 .pos2D();
 
         // for testing
-        world.getSystem(SoundSytem.class).setVolume(0);
-        world.getSystem(MusicHandler.class).setVolume(0);
-
-        world.getSystem(MusicHandler.class).fadeOutMusic(101, 0.02f);
-        world.getSystem(MusicHandler.class).playMIDI(1);
+        backGroundMusic = assetManager.getMusic ( 101 );
+        backGroundMusic.setVolume ( 0.25f );
+        backGroundMusic.play ();
+        backGroundMusic.setLooping ( true );
     }
 
     protected void update(float deltaTime) {
@@ -207,6 +208,8 @@ public class GameScreen extends ScreenAdapter implements WorldScreen {
     public void dispose() {
         world.getSystem(ClientSystem.class).stop();
         world.getSystem(GUI.class).dispose();
+        backGroundMusic.setLooping ( false );
+        backGroundMusic.stop ();
     }
 
 }

--- a/desktop/Config.json
+++ b/desktop/Config.json
@@ -8,7 +8,7 @@
       "HiDPI_Mode": "Logical"
     },
     "resizeable": true,
-    "disableAudio": true,
+    "disableAudio": false,
     "startMaximized": false,
     "tutorialTodo": "checkbox true false"
   },


### PR DESCRIPTION
**Descripción**:
En varias fases fuimos implementando el sonido. Al momento de realizar esta correción, se producían errores al querer correr el juego mediante un ejecutable y estos eran producto del sonido.
Encontramos el problema al asignar valores a la música y el sonido a través del assetmanager.
libgdx no reconocía los sonidos como cargados cuando se utilizaban los geters correspondientes y tiraba como resultado error en el assetmanager.

**Funcionalidad**:
- Lo solucionamos cambiando los return de getMusic y getSound por una forma en que  libgdx puede procesar correctamente.
- Activamos el sonido y agregamos música de fondo para poder testear.
- Ahora se reproducen los sonidos que ya estaban implementados: caminar y bloquear con escudo.