### PR TITLE
Activada las scrollbar del  Design Center. (falta la de MapEditor)

### DIFF
--- a/design/src/design/screens/views/ImageView.java
+++ b/design/src/design/screens/views/ImageView.java
@@ -115,8 +115,9 @@ public class ImageView extends View<AOImage, ImageDesigner> implements WorldScre
                 scrollableContent.row();
             }
         });
-        ScrollPane scrollPa = new ScrollPane(scrollableContent);
-        scrollPa.setDebug(true);
+        ScrollPane scrollPa = new ScrollPane(scrollableContent, SKIN );
+        scrollPa.setFlickScroll(false);
+        scrollPa.setFadeScrollBars(false);
         scrollPa.setScrollbarsVisible(true);
         content.add(scrollPa);
         return content;

--- a/design/src/design/screens/views/View.java
+++ b/design/src/design/screens/views/View.java
@@ -74,7 +74,7 @@ public abstract class View<T, P extends IDesigner<T, ? extends IDesigner.Paramet
         left.add(createButtons()).right().growX().row();
         List<T> list = createList();
         list.setTouchable(Touchable.enabled);
-        ScrollPane listScroll = new ScrollPane(list);
+        ScrollPane listScroll = new ScrollPane( list , SKIN );
         listScroll.setFlickScroll(false);
         listScroll.setFadeScrollBars(false);
         listScroll.setScrollbarsVisible(true);


### PR DESCRIPTION
Ahora son visibles las barras de desplazamiento en el design center.
Para todas las ventanas salvo el mapEditor (no esta montado sobre un scrollpane y todavía no entiendo cual es la parte que donde hay que incluirlo)