### PR TITLE
fix no muestra mensaje SEE_NOTHING

### DIFF
--- a/client/src/game/managers/AOInputProcessor.java
+++ b/client/src/game/managers/AOInputProcessor.java
@@ -112,9 +112,9 @@ public class AOInputProcessor extends Stage {
                             } else if(entity.hasName()) {
                                 gui.getConsole().addInfo( assetManager.getMessages( Messages.SEE_SOMEONE,
                                         entity.getName().text ) );
-                            } else {
-                                gui.getConsole().addInfo( assetManager.getMessages( Messages.SEE_NOTHING ) );
                             }
+                        }else {
+                            gui.getConsole().addInfo( assetManager.getMessages( Messages.SEE_NOTHING ) );
                         }
                     }
                 } ) );


### PR DESCRIPTION
la causa del error fue que al agregar 
Mejoramos mensaje en consola al clickear un objeto (#249) 
el else que da el mensaje SEE_Nothing quedo en un lugar equivocado.
re acomodado el código para que aparezca dicho msj cuando se hace click en una posición vacía