### PR TITLE
Arreglado error al tomar screenshot.

### DIFF
--- a/client/src/game/handlers/DefaultAOAssetManager.java
+++ b/client/src/game/handlers/DefaultAOAssetManager.java
@@ -291,6 +291,7 @@ public class DefaultAOAssetManager extends AssetManager implements AOAssetManage
         return weapons;
     }
 
+    @Override
     public String getMessages(Messages key, String... params) {
         if (key == null) {
             Gdx.app.error("Internationalization", "Error trying to get message");

--- a/client/src/game/ui/GUI.java
+++ b/client/src/game/ui/GUI.java
@@ -21,6 +21,7 @@ import game.utils.Skins;
 import shared.util.Messages;
 
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 public class GUI extends BaseSystem implements Disposable {
 
@@ -88,19 +89,26 @@ public class GUI extends BaseSystem implements Disposable {
     public void takeScreenshot() {
         try {
             
+            // Fetch assetManager
             AOAssetManager assetManager = AOGame.getGlobalAssetManager();
-            String screenshotPath = "Screenshots/Screenshot-" + LocalDateTime.now() + ".png";
-
+            
+            // Set where we gonna save the screenshot
+            String screenshotPath = "Screenshots/Screenshot-" + LocalDateTime.now().format(DateTimeFormatter.ofPattern("dd-MM_HH-mm-ss")) + ".png";
+            
+            // Perform the appropiate I/O opperations.
             byte[] pixels = ScreenUtils.getFrameBufferPixels(0, 0, Gdx.graphics.getBackBufferWidth(), Gdx.graphics.getBackBufferHeight(), true);
             // this loop makes sure the whole screenshot is opaque and looks exactly like what the user is seeing
             for (int i = 4; i < pixels.length; i += 4) {
                 pixels[i - 1] = (byte) 255;
             }
-
             Pixmap pixmap = new Pixmap(Gdx.graphics.getBackBufferWidth(), Gdx.graphics.getBackBufferHeight(), Pixmap.Format.RGBA8888);
             BufferUtils.copy(pixels, 0, pixmap.getPixels(), pixels.length);
             PixmapIO.writePNG(Gdx.files.local(screenshotPath), pixmap);
+            
+            // Render the message in the game console.
             getConsole().addInfo(assetManager.getMessages(Messages.SCREENSHOT, screenshotPath));
+            
+            // Clear/dispose the pixmap object.
             pixmap.dispose();
         
         } catch(Exception ex) {

--- a/client/src/game/ui/GUI.java
+++ b/client/src/game/ui/GUI.java
@@ -11,6 +11,7 @@ import com.badlogic.gdx.scenes.scene2d.ui.Table;
 import com.badlogic.gdx.utils.BufferUtils;
 import com.badlogic.gdx.utils.Disposable;
 import com.badlogic.gdx.utils.ScreenUtils;
+import com.esotericsoftware.minlog.Log;
 import game.AOGame;
 import game.handlers.AOAssetManager;
 import game.managers.AOInputProcessor;
@@ -85,20 +86,27 @@ public class GUI extends BaseSystem implements Disposable {
     }
 
     public void takeScreenshot() {
-        AOAssetManager assetManager = AOGame.getGlobalAssetManager();
-        String screenshotPath = "Screenshots/Screenshot-" + LocalDateTime.now() + ".png";
+        try {
+            
+            AOAssetManager assetManager = AOGame.getGlobalAssetManager();
+            String screenshotPath = "Screenshots/Screenshot-" + LocalDateTime.now() + ".png";
 
-        byte[] pixels = ScreenUtils.getFrameBufferPixels(0, 0, Gdx.graphics.getBackBufferWidth(), Gdx.graphics.getBackBufferHeight(), true);
-        // this loop makes sure the whole screenshot is opaque and looks exactly like what the user is seeing
-        for (int i = 4; i < pixels.length; i += 4) {
-            pixels[i - 1] = (byte) 255;
+            byte[] pixels = ScreenUtils.getFrameBufferPixels(0, 0, Gdx.graphics.getBackBufferWidth(), Gdx.graphics.getBackBufferHeight(), true);
+            // this loop makes sure the whole screenshot is opaque and looks exactly like what the user is seeing
+            for (int i = 4; i < pixels.length; i += 4) {
+                pixels[i - 1] = (byte) 255;
+            }
+
+            Pixmap pixmap = new Pixmap(Gdx.graphics.getBackBufferWidth(), Gdx.graphics.getBackBufferHeight(), Pixmap.Format.RGBA8888);
+            BufferUtils.copy(pixels, 0, pixmap.getPixels(), pixels.length);
+            PixmapIO.writePNG(Gdx.files.local(screenshotPath), pixmap);
+            getConsole().addInfo(assetManager.getMessages(Messages.SCREENSHOT, screenshotPath));
+            pixmap.dispose();
+        
+        } catch(Exception ex) {
+            Log.error("Screenshot I/O", "Error trying to take a screenshot..." , ex);
         }
-
-        Pixmap pixmap = new Pixmap(Gdx.graphics.getBackBufferWidth(), Gdx.graphics.getBackBufferHeight(), Pixmap.Format.RGBA8888);
-        BufferUtils.copy(pixels, 0, pixmap.getPixels(), pixels.length);
-        PixmapIO.writePNG(Gdx.files.local(screenshotPath), pixmap);
-        getConsole().addInfo(assetManager.getMessages(Messages.SCREENSHOT, screenshotPath));
-        pixmap.dispose();
+        
     }
 
     public void toggleFullscreen() {

--- a/shared/src/shared/util/LogSystem.java
+++ b/shared/src/shared/util/LogSystem.java
@@ -32,7 +32,11 @@ public class LogSystem extends Log.Logger {
         builder.append("] ");
         builder.append(message);
         
-        // In the .log file, this is neccesary for better readability.
+        /*
+            Para mejor visibilidad.
+            Separamos el mensaje de error de el stacktrace.
+        */
+        
         if (level == Log.LEVEL_ERROR || level == Log.LEVEL_WARN) {
             builder.append(SALTO_DE_LINEA);
         }
@@ -42,6 +46,7 @@ public class LogSystem extends Log.Logger {
             ex.printStackTrace(new PrintWriter(writer));
             builder.append(SALTO_DE_LINEA);
             builder.append(writer.toString().trim());
+            builder.append(SALTO_DE_LINEA);
 			builder.append(SALTO_DE_LINEA);
         }
 
@@ -75,8 +80,10 @@ public class LogSystem extends Log.Logger {
                 return "TRACE";
                 
             case Log.LEVEL_WARN:
-                return "WARNING";         
+                return "WARNING";
+                
+            default:
+                return "OTHER";
         }
-        return "NONE";
     }
 }

--- a/shared/src/shared/util/LogSystem.java
+++ b/shared/src/shared/util/LogSystem.java
@@ -47,7 +47,7 @@ public class LogSystem extends Log.Logger {
             builder.append(SALTO_DE_LINEA);
             builder.append(writer.toString().trim());
             builder.append(SALTO_DE_LINEA);
-			builder.append(SALTO_DE_LINEA);
+	    builder.append(SALTO_DE_LINEA);
         }
 
         // We only print ERROR logs into Errores.log

--- a/shared/src/shared/util/LogSystem.java
+++ b/shared/src/shared/util/LogSystem.java
@@ -32,7 +32,7 @@ public class LogSystem extends Log.Logger {
         builder.append("] ");
         builder.append(message);
         
-        // In the .log file, this is neccesary.
+        // In the .log file, this is neccesary for better readability.
         if (level == Log.LEVEL_ERROR || level == Log.LEVEL_WARN) {
             builder.append(SALTO_DE_LINEA);
         }
@@ -42,6 +42,7 @@ public class LogSystem extends Log.Logger {
             ex.printStackTrace(new PrintWriter(writer));
             builder.append(SALTO_DE_LINEA);
             builder.append(writer.toString().trim());
+			builder.append(SALTO_DE_LINEA);
         }
 
         // We only print ERROR logs into Errores.log


### PR DESCRIPTION
Al tratar de tomar un screenshot se crasheaba el juego.

El cliente trataba de generar un archivo cuyo nombre poseía caracteres inválidos para los estándares de los nombres de los archivos, en este caso, el `: (dos puntos)`.

Esto se arregla especificando un formato predeterminado donde la fecha y la hora que se va a guardar en el nombre de los `.png` solo use caracteres válidos.

El nombre de los `.png` de los screenshots (ahora) tienen el formato `ScreenShot-{fecha}_{hora}.png`
