### PR TITLE
Reparamos superposición de la Música y planteamos un Refactor

### DIFF
--- a/client/src/game/screens/LoginScreen.java
+++ b/client/src/game/screens/LoginScreen.java
@@ -38,6 +38,8 @@ public class LoginScreen extends AbstractScreen {
     }
 
     void bGMusic() {
+        Music backgroundmusic= MusicSystem.BACKGROUNDMUSIC;
+        backgroundmusic.stop();
         Music firstBGMusic = MusicSystem.FIRSTBGM;
         firstBGMusic.setVolume(0);
         firstBGMusic.play();

--- a/client/src/game/screens/RoomScreen.java
+++ b/client/src/game/screens/RoomScreen.java
@@ -141,10 +141,4 @@ public class RoomScreen extends AbstractScreen {
         clientSystem.getKryonetClient().sendToAll(new ChangeHeroRequest(defaultHero));
     }
 
-    @Override
-    public void dispose() {
-        clientSystem.stop();
-        MusicSystem.FIRSTBGM.stop();
-        super.dispose();
-    }
 }

--- a/client/src/game/systems/resources/MusicSystem.java
+++ b/client/src/game/systems/resources/MusicSystem.java
@@ -40,9 +40,12 @@ public class MusicSystem extends PassiveSystem {
         super.initialize();
         AOGame game = (AOGame) Gdx.app.getApplicationListener();
         assetManager = game.getAssetManager();
+        current = FIRSTBGM;
+        current.stop();
         current = BACKGROUNDMUSIC;
         current.setVolume(0.20f);
         current.play();
+        current.setLooping(false);
     }
 
     public void playMusic(int musicID) {


### PR DESCRIPTION
La música del juego se superponía con la música de la pantalla de Login. 
Revisando la falla, descubrí que se podría optimizar.
Agrego una descripción de las conclusiones que saque uds dirán. 

**La música se puede inicializar en:**
  ```
 **Pantallas**
      1 LoginScreen
      2 GameScreen
         Mapas
            numeroDeMapa
         Event //en el caso que los eventos tengan música diferente
            listaDeEventos
      3 CrearPersonaje (no implementado)
      4 Menú
```
**Las llamadas se hacen**
```
   Pantalla 1 - Loguin Screen
      allMusic.stop() (por si viene de la pantalla de juego, podría traer música de Mapa o evento)
      LoginMusic.play()
   Pantalla 2 - GameScreen
      allMusic.stop()
      hay un evento?
         event(numero).play
      sino
         map(numero).play
   Menú de opciones
      play,pause,stop, volumen.
```
**Funciones que se requieren**
```
   fadein //esta implementada y duplicada
   fadeout
```