### PR TITLE
Fix NPE en NetworkedEntitySystem

### DIFF
--- a/client/src/game/systems/world/NetworkedEntitySystem.java
+++ b/client/src/game/systems/world/NetworkedEntitySystem.java
@@ -25,25 +25,17 @@ public class NetworkedEntitySystem extends PassiveSystem {
     }
 
     public void unregisterEntity(int networkId) {
-        try {
-            int entityId = networkedEntities.get(networkId);
-            localEntities.remove(entityId);
-            world.delete(entityId);
-            networkedEntities.remove(networkId);
-        } catch (Exception e) {
-            Log.error("NetworkedEntitySystem", "unregisterEntity() couldn't remove entity: " + networkId, e);
-        }
+        int entityId = networkedEntities.get(networkId);
+        localEntities.remove(entityId);
+        world.delete(entityId);
+        networkedEntities.remove(networkId);
     }
 
     public void unregisterLocalEntity(int entityId) {
-        try {
-            Integer networkId = localEntities.get(entityId);
-            networkedEntities.remove(networkId);
-            localEntities.remove(entityId);
-            world.delete(entityId);
-        } catch (Exception e) {
-            Log.error("NetworkedEntitySystem", "unregisterLocalEntity() couldn't remove entity: " + entityId, e);
-        }
+        Integer networkId = localEntities.get(entityId);
+        networkedEntities.remove(networkId);
+        localEntities.remove(entityId);
+        world.delete(entityId);
     }
 
     public boolean exists(int networkId) {
@@ -55,7 +47,7 @@ public class NetworkedEntitySystem extends PassiveSystem {
     }
 
     public boolean existsLocal(int localId) {
-        return networkedEntities.containsKey(localId);
+        return localEntities.containsKey(localId);
     }
 
     public int getNetworkId(int localId) {

--- a/client/src/game/systems/world/NetworkedEntitySystem.java
+++ b/client/src/game/systems/world/NetworkedEntitySystem.java
@@ -31,15 +31,19 @@ public class NetworkedEntitySystem extends PassiveSystem {
             world.delete(entityId);
             networkedEntities.remove(networkId);
         } catch (Exception e) {
-            Log.error("Couldn't remove entity: " + networkId, e);
+            Log.error("NetworkedEntitySystem", "unregisterEntity() couldn't remove entity: " + networkId, e);
         }
     }
 
     public void unregisterLocalEntity(int entityId) {
-        Integer networkId = localEntities.get(entityId);
-        networkedEntities.remove(networkId);
-        localEntities.remove(entityId);
-        world.delete(entityId);
+        try {
+            Integer networkId = localEntities.get(entityId);
+            networkedEntities.remove(networkId);
+            localEntities.remove(entityId);
+            world.delete(entityId);
+        } catch (Exception e) {
+            Log.error("NetworkedEntitySystem", "unregisterLocalEntity() couldn't remove entity: " + entityId, e);
+        }
     }
 
     public boolean exists(int networkId) {


### PR DESCRIPTION
Arregla el método `NetworkedEntitySystem.existsLocal()` y se sacan los bloques Try/Catch. No debería fallar por NPE.

~~Try/Catch en NetworkedEntitySystem.unregisterLocalEntity() para no crashear por NPE:~~

```
java.lang.NullPointerException
	at java.base/java.util.concurrent.ConcurrentHashMap.replaceNode(ConcurrentHashMap.java:1111)
	at java.base/java.util.concurrent.ConcurrentHashMap.remove(ConcurrentHashMap.java:1102)
	at game.systems.world.NetworkedEntitySystem.unregisterLocalEntity(NetworkedEntitySystem.java:40)
	at game.systems.world.ClearSystem.process(ClearSystem.java:23)
	at com.artemis.systems.IteratingSystem.processSystem(IteratingSystem.java:46)
	at com.artemis.BaseSystem.process(BaseSystem.java:46)
	at com.artemis.InvocationStrategy.process(InvocationStrategy.java:25)
	at com.artemis.World.process(World.java:385)
	at game.screens.GameScreen.render(GameScreen.java:20)
	at com.badlogic.gdx.Game.render(Game.java:46)
	at com.badlogic.gdx.backends.lwjgl3.Lwjgl3Window.update(Lwjgl3Window.java:399)
	at com.badlogic.gdx.backends.lwjgl3.Lwjgl3Application.loop(Lwjgl3Application.java:137)
	at com.badlogic.gdx.backends.lwjgl3.Lwjgl3Application.<init>(Lwjgl3Application.java:111)
	at launcher.DesktopLauncher.main(DesktopLauncher.java:87)
```