### PR TITLE
Hotfix IndexOutOfBounds en CommandSystem

### DIFF
--- a/server/src/server/systems/CommandSystem.java
+++ b/server/src/server/systems/CommandSystem.java
@@ -69,7 +69,7 @@ public class CommandSystem extends DefaultManager {
             int playerMap = player.worldPosMap(), playerX = player.worldPosX(), playerY = player.worldPosY();
             boolean homeSet = false;
             int i = 0;
-            while ((i < capacity ) || homeSet) {
+            while ((i < capacity) && !homeSet) {
                 if (playerMap == cityMaps.get( i )){
                     player.originPosMap( playerMap ).originPosX( playerX ).originPosY( playerY );
                     messageSystem.add(senderId, ConsoleMessage.info("HOME_SET"));


### PR DESCRIPTION
```
Fri Apr 24 16:54:55 ART 2020 [ERROR] [Command Parser] Error al ejecutar comando: /sethome

java.lang.IndexOutOfBoundsException: index can't be >= size: 17 >= 17
	at com.badlogic.gdx.utils.Array.get(Array.java:154)
	at server.systems.CommandSystem.lambda$new$3(CommandSystem.java:78)
	at server.systems.CommandSystem.handleCommand(CommandSystem.java:127)
	at server.network.ServerRequestProcessor.processRequest(ServerRequestProcessor.java:191)
	at shared.network.interaction.TalkRequest.accept(TalkRequest.java:23)
	at server.systems.ServerSystem.processJob(ServerSystem.java:50)
	at server.systems.ServerSystem.processSystem(ServerSystem.java:63)
	at com.artemis.BaseSystem.process(BaseSystem.java:46)
	at com.artemis.InvocationStrategy.process(InvocationStrategy.java:25)
	at com.artemis.World.process(World.java:385)
	at server.core.Finisterra.render(Finisterra.java:127)
	at com.badlogic.gdx.backends.headless.HeadlessApplication.mainLoop(HeadlessApplication.java:129)
	at com.badlogic.gdx.backends.headless.HeadlessApplication$1.run(HeadlessApplication.java:96)
```