### PR TITLE
Removido drop de item que no existe

### DIFF
--- a/server/resources/NPCs.dat
+++ b/server/resources/NPCs.dat
@@ -5193,8 +5193,7 @@ BackUp=0
 NROITEMS=5
 Drop1=12-2 
 Drop3=28-10 
-Drop4=534-10 
-Drop5=12-100 
+Drop4=12-100
 
 
 


### PR DESCRIPTION
Posiblemente relacionado a #250 ya que cuando tenias el item inexistente en el inventario e intentabas equipar un item cualquiera, este no se equipaba.