### PR TITLE
Fix login y múltiples conexiones

### DIFF
--- a/client/src/game/screens/CharacterSelectionScreen.java
+++ b/client/src/game/screens/CharacterSelectionScreen.java
@@ -251,6 +251,7 @@ public class CharacterSelectionScreen extends AbstractScreen {
         toLoginButton.addListener(new ChangeListener() {
             @Override
             public void changed(ChangeEvent event, Actor actor) {
+                clientSystem.stop();
                 screenManager.to(ScreenEnum.LOGIN);
             }
         });

--- a/client/src/game/screens/CharacterSelectionScreen.java
+++ b/client/src/game/screens/CharacterSelectionScreen.java
@@ -38,7 +38,6 @@ public class CharacterSelectionScreen extends AbstractScreen {
     private ArrayList<Table> userTableArray, userImageTableArray;
     private ArrayList<Label> nameLabelArray, HPLabelArray, MPLabelArray;
     private ArrayList<TextButton> playButtonArray, createButtonArray;
-    private ArrayList<Boolean> booleanArrayList;
     private Image heroSelectionImage;
     private Window charSelectWindows, createWindow;
     private TextButton registerButton;
@@ -63,7 +62,6 @@ public class CharacterSelectionScreen extends AbstractScreen {
         MPLabelArray = new ArrayList<>();
         userImageTableArray = new ArrayList<>();
         playButtonArray = playButtonArray != null ? playButtonArray : new ArrayList<>();
-        booleanArrayList = booleanArrayList != null ? booleanArrayList : new ArrayList<>();
 
         charSelectWindows = WidgetFactory.createWindow();
         createWindow = WidgetFactory.createWindow();
@@ -192,9 +190,9 @@ public class CharacterSelectionScreen extends AbstractScreen {
                     MPLabelArray.get(i).setText(userCharactersData.get(i + 18) + " / " + userCharactersData.get(i + 24));
                     nameLabelArray.get(i).setText(charName);
                     if (userHeroID != -1) {
+                        playButtonArray.get(i).setDisabled(false);
                         playButtonListener(i, charName);
                     }
-
                 } else {
                     playButtonArray.get(i).setDisabled(true);
                 }
@@ -286,21 +284,20 @@ public class CharacterSelectionScreen extends AbstractScreen {
         playButtonArray.get(index).addListener(new ChangeListener() {
             @Override
             public void changed(ChangeEvent event, Actor actor) {
+                // deshabilitamos los botones temporalmente
+                for (TextButton playButton : playButtonArray) {
+                    if (!playButton.isDisabled()) {
+                        playButton.setDisabled(true);
+                        Timer.schedule(new Timer.Task() {
+                            @Override
+                            public void run() {
+                                playButton.setDisabled(false);
+                            }
+                        }, 3);
+                    }
+                }
                 // send request to login user
                 clientSystem.send(new UserContinueRequest(userName));
-                for (int x = 0; x < 6; x++) {
-                    if (booleanArrayList.size() < 6)
-                        booleanArrayList.add(x, playButtonArray.get(x).isDisabled());
-                    playButtonArray.get(x).setDisabled(true);
-                }
-                Timer.schedule(new Timer.Task() {
-                    @Override
-                    public void run() {
-                        for (int y = 0; y < 6; y++) {
-                            playButtonArray.get(y).setDisabled(booleanArrayList.get(y));
-                        }
-                    }
-                }, 3);
             }
         });
     }

--- a/client/src/game/systems/input/InputSystem.java
+++ b/client/src/game/systems/input/InputSystem.java
@@ -3,7 +3,6 @@ package game.systems.input;
 import com.artemis.annotations.Wire;
 import com.badlogic.gdx.Input;
 import com.badlogic.gdx.InputProcessor;
-import game.screens.ScreenEnum;
 import game.screens.ScreenManager;
 import game.systems.actions.PlayerActionSystem;
 import game.systems.camera.CameraSystem;
@@ -58,8 +57,7 @@ public class InputSystem extends PassiveSystem implements InputProcessor {
                 alternativeKeys = !alternativeKeys;
                 break;
             case Input.Keys.ESCAPE:
-                clientSystem.stop();
-                screenManager.to(ScreenEnum.LOGIN);
+                clientSystem.logout();
                 break;
         }
 

--- a/client/src/game/systems/network/ClientResponseProcessor.java
+++ b/client/src/game/systems/network/ClientResponseProcessor.java
@@ -17,6 +17,7 @@ import shared.network.movement.MovementResponse;
 import shared.network.time.TimeSyncResponse;
 import shared.network.user.UserCreateResponse;
 import shared.network.user.UserLoginResponse;
+import shared.network.user.UserLogoutResponse;
 
 @Wire
 public class ClientResponseProcessor extends PassiveSystem implements IResponseProcessor {
@@ -81,6 +82,14 @@ public class ClientResponseProcessor extends PassiveSystem implements IResponseP
             screenManager.to(ScreenEnum.GAME);
         } else {
             screenManager.showDialog("Error", userLoginResponse.getMessage());
+        }
+    }
+    @Override
+    public void processResponse(@NotNull UserLogoutResponse userLogoutResponse) {
+        if (userLogoutResponse.isSuccessful()) {
+            clientSystem.disconnect();
+        } else {
+            screenManager.showDialog("Error", userLogoutResponse.getMessage());
         }
     }
 }

--- a/client/src/game/systems/network/ClientSystem.java
+++ b/client/src/game/systems/network/ClientSystem.java
@@ -11,6 +11,7 @@ import net.mostlyoriginal.api.network.system.MarshalSystem;
 import shared.network.init.NetworkDictionary;
 import shared.network.interfaces.INotification;
 import shared.network.interfaces.IResponse;
+import shared.network.user.UserLogoutRequest;
 
 @Wire
 public class ClientSystem extends MarshalSystem {
@@ -61,6 +62,16 @@ public class ClientSystem extends MarshalSystem {
         if (screenManager.getScreen() instanceof GameScreen) {
             Gdx.app.postRunnable(() -> screenManager.to(ScreenEnum.LOGIN));
         }
+    }
+
+    public void logout(){
+        send(new UserLogoutRequest());
+    }
+
+    public void disconnect(){
+        getKryonetClient().getClient().close();
+        stop();
+        Log.info( getState() + "" );
     }
 
     public boolean connect() {

--- a/server/src/server/core/ServerStrategy.java
+++ b/server/src/server/core/ServerStrategy.java
@@ -1,5 +1,6 @@
 package server.core;
 
+import com.esotericsoftware.kryonet.Connection;
 import com.esotericsoftware.kryonet.Server;
 import com.esotericsoftware.minlog.Log;
 import net.mostlyoriginal.api.network.marshal.common.MarshalState;
@@ -25,7 +26,7 @@ public class ServerStrategy extends KryonetMarshalStrategy {
     @Override
     protected void connectEndpoint() {
         try {
-            ((Server) endpoint).bind(tcpPort, udpPort);
+            ((Server)endpoint).bind(tcpPort, udpPort);
             Log.info("Server initialization", "Listening connections in ports TCP: " + tcpPort + " and UDP: " + udpPort);
             state = MarshalState.STARTED;
         } catch (IOException e) {
@@ -36,11 +37,20 @@ public class ServerStrategy extends KryonetMarshalStrategy {
 
     @Override
     public void sendToAll(Object o) {
-        ((Server) endpoint).sendToAllTCP(o);
+        ((Server)endpoint).sendToAllTCP(o);
     }
 
-    public void sendTo(int connectionId, Object o) {
-        ((Server) endpoint).sendToTCP(connectionId, o);
+    public void sendTo(int connectionID, Object o) {
+        ((Server)endpoint).sendToTCP(connectionID, o);
     }
 
+    public Connection getConnection(int connectionID) {
+        Connection[] connections = ((Server)endpoint).getConnections();
+        for (Connection connection : connections) {
+            if (connection.getID() == connectionID) {
+                return connection;
+            }
+        }
+        return null;
+    }
 }

--- a/server/src/server/systems/account/AccountSystem.java
+++ b/server/src/server/systems/account/AccountSystem.java
@@ -28,8 +28,7 @@ public class AccountSystem extends PassiveSystem {
             accountDir.mkdirs();
     }
 
-    public void createAccount(int connectionId, String username, String email, String password) {
-
+    public void createAccount(int connectionID, String username, String email, String password) {
         // Hasheamos la contraseña.
         String hashedPassword = AccountSystemUtilities.hashPassword(password);
 
@@ -47,19 +46,21 @@ public class AccountSystem extends PassiveSystem {
             }
         }
 
-        serverSystem.sendTo(connectionId, new AccountCreationResponse(successful));
+        serverSystem.sendTo(connectionID, new AccountCreationResponse(successful));
+        serverSystem.closeConnection(connectionID);
     }
 
-    public void login(int connectionId, String email, String password) {
+    public void loginAccount(int connectionID, String email, String password) {
         // Obtenemos la cuenta de la carpeta Accounts.
         Account requestedAccount = Account.load(email);
 
         if (requestedAccount == null) {
-            serverSystem.sendTo(connectionId, new AccountLoginResponse(Messages.NON_EXISTENT_ACCOUNT));
+            serverSystem.sendTo(connectionID, new AccountLoginResponse(Messages.NON_EXISTENT_ACCOUNT));
+            serverSystem.closeConnection(connectionID);
             return;
-
         } else if (!AccountSystemUtilities.checkPassword(password, requestedAccount.getPassword())) {
-            serverSystem.sendTo(connectionId, new AccountLoginResponse(Messages.ACCOUNT_LOGIN_FAILED));
+            serverSystem.sendTo(connectionID, new AccountLoginResponse(Messages.ACCOUNT_LOGIN_FAILED));
+            serverSystem.closeConnection(connectionID);
             return;
         }
 
@@ -115,7 +116,7 @@ public class AccountSystem extends PassiveSystem {
             }
         }
 
-        serverSystem.sendTo(connectionId, new AccountLoginResponse(email, characters, charactersData));
+        serverSystem.sendTo(connectionID, new AccountLoginResponse(email, characters, charactersData));
     }
 
     public Account getAccount(String email) {

--- a/server/src/server/systems/network/ServerRequestProcessor.java
+++ b/server/src/server/systems/network/ServerRequestProcessor.java
@@ -57,8 +57,7 @@ public class ServerRequestProcessor extends DefaultRequestProcessor {
     public void processRequest(@NotNull AccountLoginRequest accountLoginRequest, int connectionId) {
         String email = accountLoginRequest.getEmail();
         String password = accountLoginRequest.getPassword();
-
-        accountSystem.login(connectionId, email, password);
+        accountSystem.loginAccount(connectionId, email, password);
     }
 
     // Users

--- a/server/src/server/systems/network/ServerRequestProcessor.java
+++ b/server/src/server/systems/network/ServerRequestProcessor.java
@@ -24,6 +24,7 @@ import shared.network.time.TimeSyncResponse;
 import shared.network.user.UserContinueRequest;
 import shared.network.user.UserCreateRequest;
 import shared.network.user.UserLoginRequest;
+import shared.network.user.UserLogoutRequest;
 
 /**
  * Every packet received from users will be processed here
@@ -71,6 +72,11 @@ public class ServerRequestProcessor extends DefaultRequestProcessor {
     @Override
     public void processRequest(UserContinueRequest userContinueRequest, int connectionId) {
         userSystem.login(connectionId, userContinueRequest.getName());
+    }
+
+    @Override
+    public void processRequest(UserLogoutRequest userLogoutRequest, int connectionId) {
+        userSystem.userLogout(connectionId);
     }
 
     @Override

--- a/server/src/server/systems/network/ServerSystem.java
+++ b/server/src/server/systems/network/ServerSystem.java
@@ -1,5 +1,6 @@
 package server.systems.network;
 
+import com.artemis.E;
 import com.artemis.annotations.Wire;
 import com.badlogic.gdx.Gdx;
 import com.esotericsoftware.minlog.Log;
@@ -7,6 +8,7 @@ import net.mostlyoriginal.api.network.marshal.common.MarshalStrategy;
 import net.mostlyoriginal.api.network.system.MarshalSystem;
 import server.configs.ServerConfiguration;
 import server.core.ServerStrategy;
+import server.systems.account.UserSystem;
 import server.systems.config.ConfigurationSystem;
 import server.systems.world.MapSystem;
 import server.systems.world.WorldEntitiesSystem;
@@ -28,6 +30,7 @@ public class ServerSystem extends MarshalSystem {
     private ServerRequestProcessor requestProcessor;
     private WorldEntitiesSystem worldEntitiesSystem;
     private ConfigurationSystem configurationSystem;
+    private UserSystem userSystem;
 
     private Deque<NetworkJob> netQueue = new ConcurrentLinkedDeque<>();
 
@@ -78,13 +81,17 @@ public class ServerSystem extends MarshalSystem {
     }
 
     @Override
-    public void disconnected(int connectionId) {
-        super.disconnected(connectionId);
-        if (connectionHasNoPlayer(connectionId)) {
+    public void disconnected(int connectionID) {
+        super.disconnected(connectionID);
+        if (connectionHasNoPlayer(connectionID)) {
             return;
         }
         Gdx.app.postRunnable(() -> {
-            worldEntitiesSystem.unregisterEntity(getPlayerByConnection(connectionId));
+            int playerID = getPlayerByConnection(connectionID);
+            E player = E.E(playerID);
+            String username = player.nameText();
+            worldEntitiesSystem.unregisterEntity(getPlayerByConnection(connectionID));
+            userSystem.logout(username);
         });
     }
 

--- a/server/src/server/systems/network/ServerSystem.java
+++ b/server/src/server/systems/network/ServerSystem.java
@@ -30,6 +30,9 @@ public class ServerSystem extends MarshalSystem {
     private ConfigurationSystem configurationSystem;
 
     private Deque<NetworkJob> netQueue = new ConcurrentLinkedDeque<>();
+
+    // @todo acá se podría usar BiMap de Google Guava
+    // @see https://github.com/google/guava/wiki/NewCollectionTypesExplained#bimap
     private Map<Integer, Integer> playerByConnection = new ConcurrentHashMap<>();
     private Map<Integer, Integer> connectionByPlayer = new ConcurrentHashMap<>();
 
@@ -83,6 +86,11 @@ public class ServerSystem extends MarshalSystem {
         Gdx.app.postRunnable(() -> {
             worldEntitiesSystem.unregisterEntity(getPlayerByConnection(connectionId));
         });
+    }
+
+    public void closeConnection(int connectionID) {
+        ServerStrategy marshal = (ServerStrategy) getMarshal();
+        marshal.getConnection(connectionID).close();
     }
 
     /**

--- a/shared/src/shared/network/init/NetworkDictionary.java
+++ b/shared/src/shared/network/init/NetworkDictionary.java
@@ -131,6 +131,8 @@ public class NetworkDictionary extends MarshalDictionary {
                 UserCreateRequest.class,
                 UserLoginResponse.class,
                 UserCreateResponse.class,
+                UserLogoutRequest.class,
+                UserLogoutResponse.class,
 
                 // Other
                 boolean[][].class,

--- a/shared/src/shared/network/interfaces/DefaultRequestProcessor.java
+++ b/shared/src/shared/network/interfaces/DefaultRequestProcessor.java
@@ -12,6 +12,7 @@ import shared.network.time.TimeSyncRequest;
 import shared.network.user.UserContinueRequest;
 import shared.network.user.UserCreateRequest;
 import shared.network.user.UserLoginRequest;
+import shared.network.user.UserLogoutRequest;
 
 public class DefaultRequestProcessor extends PassiveSystem implements IRequestProcessor {
 
@@ -91,4 +92,8 @@ public class DefaultRequestProcessor extends PassiveSystem implements IRequestPr
 
     }
 
+    @Override
+    public void processRequest(UserLogoutRequest userLogoutRequest, int connectionId) {
+
+    }
 }

--- a/shared/src/shared/network/interfaces/IRequestProcessor.java
+++ b/shared/src/shared/network/interfaces/IRequestProcessor.java
@@ -11,6 +11,7 @@ import shared.network.time.TimeSyncRequest;
 import shared.network.user.UserContinueRequest;
 import shared.network.user.UserCreateRequest;
 import shared.network.user.UserLoginRequest;
+import shared.network.user.UserLogoutRequest;
 
 public interface IRequestProcessor {
 
@@ -43,4 +44,6 @@ public interface IRequestProcessor {
     void processRequest(UserLoginRequest userLoginRequest, int connectionId);
 
     void processRequest(UserContinueRequest userContinueRequest, int connectionId);
+
+    void processRequest(UserLogoutRequest userLogoutRequest, int connectionId);
 }

--- a/shared/src/shared/network/interfaces/IResponseProcessor.java
+++ b/shared/src/shared/network/interfaces/IResponseProcessor.java
@@ -6,6 +6,7 @@ import shared.network.movement.MovementResponse;
 import shared.network.time.TimeSyncResponse;
 import shared.network.user.UserCreateResponse;
 import shared.network.user.UserLoginResponse;
+import shared.network.user.UserLogoutResponse;
 
 public interface IResponseProcessor {
 
@@ -20,4 +21,6 @@ public interface IResponseProcessor {
     void processResponse(UserCreateResponse userCreateResponse);
 
     void processResponse(UserLoginResponse userLoginResponse);
+
+    void processResponse(UserLogoutResponse userLogoutResponse);
 }

--- a/shared/src/shared/network/user/UserLogoutRequest.java
+++ b/shared/src/shared/network/user/UserLogoutRequest.java
@@ -1,0 +1,11 @@
+package shared.network.user;
+
+import shared.network.interfaces.IRequest;
+import shared.network.interfaces.IRequestProcessor;
+
+public class UserLogoutRequest implements IRequest {
+    @Override
+    public void accept(IRequestProcessor processor, int connectionId) {
+        processor.processRequest(this, connectionId);
+    }
+}

--- a/shared/src/shared/network/user/UserLogoutResponse.java
+++ b/shared/src/shared/network/user/UserLogoutResponse.java
@@ -1,0 +1,40 @@
+package shared.network.user;
+
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+import shared.network.interfaces.IResponse;
+import shared.network.interfaces.IResponseProcessor;
+
+public class UserLogoutResponse implements IResponse {
+
+    private boolean ok = true;
+    private String message;
+
+    public UserLogoutResponse() {
+
+    }
+    @Contract(value = " -> new", pure = true)
+    public static @NotNull UserLogoutResponse ok() {
+        return new UserLogoutResponse();
+    }
+    public static @NotNull UserLogoutResponse failed(String message) {
+        UserLogoutResponse userLogoutResponse = new UserLogoutResponse();
+        userLogoutResponse.ok = false;
+        userLogoutResponse.message = message;
+        return userLogoutResponse;
+    }
+
+    public boolean isSuccessful() {
+        return ok;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+
+    @Override
+    public void accept(IResponseProcessor processor) {
+        processor.processResponse(this);
+    }
+}


### PR DESCRIPTION
El servidor puede cerrar conexiones de manera unilateral. Cierra la conexión después de crear una cuenta.
El servidor mantiene una lista de usuarios conectados y chequea que el usuario no esté conectado al loguear.
Arregla el bug del botón jugar deshabilitado después de crear un PJ.